### PR TITLE
Update activation event to activate on ember config only

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
     "url": "https://github.com/suchitadoshi1987/vscode-ember/issues"
   },
   "activationEvents": [
-    "onLanguage:handlebars",
-    "onLanguage:javascript",
-    "onLanguage:typescript",
     "workspaceContains:ember-cli-build.js",
     "onCommand:els.runInEmberCLI"
   ],


### PR DESCRIPTION
Currently we activate ELS extension on all projects that has JS, TS or hbs. Its not necessary that they would be ember projects. This PR will only activate if the project is an ember app.