### PR TITLE
Support child level existance of ember-cli-build

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/suchitadoshi1987/vscode-ember/issues"
   },
   "activationEvents": [
-    "workspaceContains:ember-cli-build.js",
+    "workspaceContains:**/ember-cli-build.js",
     "onCommand:els.runInEmberCLI"
   ],
   "contributes": {


### PR DESCRIPTION
Currently, the activation event only supported top level existence of `ember-cli-build.js`. However, there can be cases where there are ember apps within a parent folder. This PR enables activation for ELS for child level presence of `ember-cli-build.js`